### PR TITLE
Add instructions to switch FreeBSD pkg repo to latest

### DIFF
--- a/docs/Getting-Started/Installation/FreeBSD/freebsd.md
+++ b/docs/Getting-Started/Installation/FreeBSD/freebsd.md
@@ -1,15 +1,15 @@
 # FreeBSD
 
+1. Make sure you use /latest pkg repository
+
+    * Ensure your pkg repo is configured to get packages from `/latest` and not `/quarterly`
+    * Check `/usr/local/etc/pkg/repos/FreeBSD.conf`
+    * If that does not exist, copy over `/etc/pkg/FreeBSD.conf` to that location, open it, and replace `quarterly` with `latest`
+
 1. Install the required software:
 
     ```bash
     pkg update && pkg install bazarr
-    ```
-
-    If you want to use the latest beta use
-
-    ```bash
-    pkg update && pkg install bazarr-devel
     ```
 
 1. Enable bazarr during startup


### PR DESCRIPTION
While at it, remove the bazarr-devel package as it's no
longer available in the official freebsd repository.