### PR TITLE
docs: explicitly reference /opt/folder

### DIFF
--- a/docs/Getting-Started/Installation/Linux/linux.md
+++ b/docs/Getting-Started/Installation/Linux/linux.md
@@ -23,6 +23,12 @@ thnx to @inquilino for the fixes/updates
 
 1. Upgrade Python to version 3.7 or greater.
 1. Download latest release of Bazarr [here](https://github.com/morpheus65535/bazarr/releases/latest/download/bazarr.zip)
+1. Create the `bazarr` directory
+
+    ```shell
+    sudo mkdir /opt/bazarr
+    ```
+
 1. Extract the content of the zipped release to the previously created `bazarr` directory
 1. Install Python requirements using:
 


### PR DESCRIPTION
Thanks for building and maintaining bazarr -  I'm a huge fan!

This PR adds an explicit installation step for Linux, the  `/opt/bazarr` directory was referenced but not clearly created, so I've added that.