### PR TITLE
Fix MacOS autostart installation instruction path

### DIFF
--- a/docs/Getting-Started/Autostart/MacOS/macos.md
+++ b/docs/Getting-Started/Autostart/MacOS/macos.md
@@ -1,6 +1,6 @@
 # MacOS
 
-Install Bazarr following the [instructions](../../Installation/MacOS/macos)
+Install Bazarr following the [instructions](../../Installation/MacOS/macos.md)
 
 ## LaunchAgent on MacOS
 


### PR DESCRIPTION
# Description

The path is missing the `.md`. extension which will result in a broken link.