### PR TITLE
Configuring Postgresql when running the container as a non-root user.

### DIFF
--- a/docs/Additional-Configuration/PostgreSQL-Database.md
+++ b/docs/Additional-Configuration/PostgreSQL-Database.md
@@ -44,6 +44,17 @@ Alternatively you may use the environment variables `POSTGRES_ENABLED`, `POSTGRE
 
 If you do not want to migrate an existing SQLite database to Postgres then you have already reached the end of this guide and you can simply start Bazarr!
 
+!!! note Running Bazarr radar as non-root
+
+    When running the container Bazarr as non root (ie. UID=1000,GID=1000) it might raise the following error:
+
+    ```
+    sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "bazarr-database" (192.168.1.123), port 5432 failed: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied
+    connection to server at "bazarr-database" (192.168.1.123), port 5432 failed: FATAL:  pg_hba.conf rejects connection for host "127.0.0.6", user "bazarr-user", database "bazarr_database", no encryption
+    ```
+
+    This can be addressed by setting the environment variable **PGSSLCERT** to "/tmp/postgresql.crt" or any other path that the user has access to. 
+
 ## Data migration
 
 Once the database has been created, you can start the Bazarr migration from SQLite to Postgres. Make sure that your SQLite database has been used with Bazarr 1.1.5 or greater prior to migration.

--- a/docs/Additional-Configuration/PostgreSQL-Database.md
+++ b/docs/Additional-Configuration/PostgreSQL-Database.md
@@ -44,7 +44,7 @@ Alternatively you may use the environment variables `POSTGRES_ENABLED`, `POSTGRE
 
 If you do not want to migrate an existing SQLite database to Postgres then you have already reached the end of this guide and you can simply start Bazarr!
 
-!!! note Running Bazarr radar as non-root
+!!! note "Running Bazarr radar as non-root"
 
     When running the container Bazarr as non root (ie. UID=1000,GID=1000) it might raise the following error:
 

--- a/docs/Additional-Configuration/PostgreSQL-Database.md
+++ b/docs/Additional-Configuration/PostgreSQL-Database.md
@@ -46,7 +46,7 @@ If you do not want to migrate an existing SQLite database to Postgres then you h
 
 !!! note "Running linuxserver.io Bazarr as non-root"
 
-    When running [linuxserver.io Bazarr image](https://docs.linuxserver.io/images/docker-prowlarr/) as non root (ie. UID=1000,GID=1000) it might raise the following error:
+    When running [linuxserver.io Bazarr image](https://docs.linuxserver.io/images/docker-bazarr/) as non root (ie. UID=1000,GID=1000) it might raise the following error:
 
     ```
     sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "bazarr-database" (192.168.1.123), port 5432 failed: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied

--- a/docs/Additional-Configuration/PostgreSQL-Database.md
+++ b/docs/Additional-Configuration/PostgreSQL-Database.md
@@ -44,9 +44,9 @@ Alternatively you may use the environment variables `POSTGRES_ENABLED`, `POSTGRE
 
 If you do not want to migrate an existing SQLite database to Postgres then you have already reached the end of this guide and you can simply start Bazarr!
 
-!!! note "Running Bazarr radar as non-root"
+!!! note "Running linuxserver.io Bazarr as non-root"
 
-    When running the container Bazarr as non root (ie. UID=1000,GID=1000) it might raise the following error:
+    When running [linuxserver.io Bazarr image](https://docs.linuxserver.io/images/docker-prowlarr/) as non root (ie. UID=1000,GID=1000) it might raise the following error:
 
     ```
     sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "bazarr-database" (192.168.1.123), port 5432 failed: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied

--- a/docs/Additional-Configuration/PostgreSQL-Database.md
+++ b/docs/Additional-Configuration/PostgreSQL-Database.md
@@ -53,7 +53,7 @@ If you do not want to migrate an existing SQLite database to Postgres then you h
     connection to server at "bazarr-database" (192.168.1.123), port 5432 failed: FATAL:  pg_hba.conf rejects connection for host "127.0.0.6", user "bazarr-user", database "bazarr_database", no encryption
     ```
 
-    This can be addressed by setting the environment variable **PGSSLCERT** to "/tmp/postgresql.crt" or any other path that the user has access to. 
+    This can be addressed by setting the environment variable **PGSSLCERT** to "/tmp/postgresql.crt" or any other path that the user has access to.
 
 ## Data migration
 


### PR DESCRIPTION
Using container [**linuxserver.io** image](https://docs.linuxserver.io/images/docker-bazarr/), when the ENV PUID is not set to root/0 it raises the following error:

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "bazarr-db" (10.105.54.22), port 5432 failed: could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied
connection to server at "bazarr-db" (10.105.54.22), port 5432 failed: FATAL:  pg_hba.conf rejects connection for host "127.0.0.6", user "bazarr", database "bazarr_db", no encryption
```

To circumvent this, the ENV variable **PGSSLCERT** can be populated with a path the user has access to.

ie.
```
PGSSLCERT="/tmp/postgresql.crt"
```

Nevertheless I'm not sure if that's something that want to be specified within the Wiki.