### PR TITLE
fix: Wrong thresholds for Whisper Provider

### DIFF
--- a/docs/Additional-Configuration/Whisper-Provider.md
+++ b/docs/Additional-Configuration/Whisper-Provider.md
@@ -6,7 +6,9 @@ Whisper (based on [OpenAI Whisper](https://github.com/openai/whisper)) uses a ne
 
 Whisper supports transcribing in many languages as well as translating from a language to English. The provider works best when it knows the audio language ahead of time. Make sure the 'Deep analyze media file to get audio tracks language' option is enabled to ensure the best results.
 
-Minimum score must be lowered if you want whisper generated subtitles to be automatically "downloaded" because they have a fixed score which is 220/360 (~61%) for episodes and 40/120 (~33%) for movies.
+Minimum score must be lowered if you want whisper generated subtitles to be automatically "downloaded" because they have a fixed score which is 220/360 (~61%) for episodes and 60/180 (~33%) for movies.
+
+These scores are fixed because Whisper always matches only `series` + `season` + `episode` for episodes and `title` for movies (see [morpheus65535:bazarr/custom_libs/subliminal_patch/providers/whisperai.py](https://github.com/morpheus65535/bazarr/blob/master/custom_libs/subliminal_patch/providers/whisperai.py) the `get_matches` method), against the point values defined in [morpheus65535:bazarr/custom_libs/subliminal_patch/providers/whisperai.py](https://github.com/morpheus65535/bazarr/blob/master/custom_libs/subliminal_patch/score.py). The score may be +1 higher (221/360 or 61/180) if your language profile's hearing impaired preference matches the subtitle.
 
 ## whisper-asr-webservice [SubGen]
 


### PR DESCRIPTION
## Summary

Fix incorrect Whisper provider subtitle scores in the Wiki. The current values don't match what Bazarr actually assigns, which causes automatic downloads to silently fail when using default minimum score thresholds.

## Problem

The Wiki states Whisper subtitles receive 241/360 (~67%) for episodes and 61/120 (~51%) for movies. This appears outdated and the actual scores appear to be **220/360 (~61%)** for episodes and **60/180 (~33%)** for movies.

When the scores are set to [the values in the wiki](https://wiki.bazarr.media/Additional-Configuration/Whisper-Provider/), no subtitles are ever fetched from Whisper.

### Steps to reproduce

1. Enable the Whisper provider as the only subtitle source.
2. Leave minimum scores at their defaults.
3. Observe that automatic subtitle downloads never trigger for movies.
4. Run a manual search in the Bazarr UI. The Whisper result shows a score of 33% for movies, below the default threshold.

### Solution

If you set the minimum score for episodes below 61 and the minimum score for movies below 33, the Whisper provider begins returning subtitles once again.

## Environment

| Component | Value |
| --------- | ----- |
| Bazarr Version | 1.5.7-beta.8 ([nightly-3be3d98, hotio](https://hotio.dev/containers/bazarr/)) |
| Whisper ASR Image | [`onerahmet/openai-whisper-asr-webservice:latest-gpu`](https://hub.docker.com/r/onerahmet/openai-whisper-asr-webservice) ([`29ba705a475c`](https://hub.docker.com/layers/onerahmet/openai-whisper-asr-webservice/latest-gpu/images/sha256-29ba705a475c1a2b8729408d25be23c7c2ff7ccaa1d30ab7d7c6e03ac3026b36)) |
| Whisper Engine | faster_whisper |
| Whisper Model | large-v3 |
| Whisper Package | 1.1.1 |
| CUDA | 12.6.3 (float16) |
| GPU | NVIDIA GeForce RTX 2070 SUPER (8 GB) |